### PR TITLE
Improve workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   golangci-lint:
     name: runner / golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,19 +12,19 @@ jobs:
     strategy:
       matrix:
         go-version: [1.16.x, 1.17.x]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: check out code into the Go module directory
         uses: actions/checkout@v2
 
       - name: set up Go 1.1x
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: restore cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
- Pin runner OS version to `ubuntu-20.04`
- Bump `actions/setup-go` and `actions/cache` from v1 to v2