### PR TITLE
fix(timelines): fix

### DIFF
--- a/timelines.go
+++ b/timelines.go
@@ -13,7 +13,7 @@ func userTweetTimeline(ctx context.Context, c *client, id string, opt ...*UserTw
 	if len(id) == 0 {
 		return nil, errors.New("user tweet timeline: id parameter is required")
 	}
-	userTweetTimeline := timeline + "?id=" + id + "/tweets"
+	userTweetTimeline := timeline + "/" + id + "/tweets"
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, userTweetTimeline, nil)
 	if err != nil {
@@ -58,7 +58,7 @@ func userMentionTimeline(ctx context.Context, c *client, id string, opt ...*User
 	if len(id) == 0 {
 		return nil, errors.New("user mention timeline: id parameter is required")
 	}
-	userMentionTimeline := timeline + "?id=" + id + "/mentions"
+	userMentionTimeline := timeline + "/" + id + "/mentions"
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, userMentionTimeline, nil)
 	if err != nil {

--- a/tweet_option.go
+++ b/tweet_option.go
@@ -154,7 +154,7 @@ func (t UserTweetTimelineOption) addQuery(req *http.Request) {
 	if !t.EndTime.IsZero() {
 		q.Add("end_time", t.EndTime.Format(time.RFC3339))
 	}
-	if t.MaxResults > 0 {
+	if 5 <= t.MaxResults && t.MaxResults <= 100 {
 		q.Add("max_results", strconv.Itoa(t.MaxResults))
 	}
 	if len(t.PaginationToken) > 0 {
@@ -212,7 +212,7 @@ func (t UserMentionTimelineOption) addQuery(req *http.Request) {
 	if !t.EndTime.IsZero() {
 		q.Add("end_time", t.EndTime.Format(time.RFC3339))
 	}
-	if t.MaxResults > 0 {
+	if 5 <= t.MaxResults && t.MaxResults <= 100 {
 		q.Add("max_results", strconv.Itoa(t.MaxResults))
 	}
 	if len(t.PaginationToken) > 0 {


### PR DESCRIPTION
## fix point
1. path of url is wrong
ref: [timelines api](https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference)
`?id=` → `:id`
2. add validation for `max_results` 
the user was able to send a request by entering a number less than 5 or greater than 100 for the value of `max_results`.
In other words, it can cause unintentional errors,  so I fixed it.
- ref: [User Tweet timeline](https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-tweets)
- ref: [User mention timeline](https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-mentions)
<img width="891" alt="スクリーンショット 2021-11-27 0 56 57" src="https://user-images.githubusercontent.com/39262724/143606291-59ac50c3-239b-494f-8800-45e485291635.png">

<img width="889" alt="スクリーンショット 2021-11-27 0 57 28" src="https://user-images.githubusercontent.com/39262724/143606329-3459d44d-7d8f-4a88-8779-d8243a275f03.png">
  