### PR TITLE
add api of ListSpecifiedUserMemberOf

### DIFF
--- a/client.go
+++ b/client.go
@@ -57,7 +57,7 @@ type Lists interface {
 	LookUpAllListsOwned(ctx context.Context, userID string, opt ...*AllListsOwnedOption) (*AllListsOwnedResponse, error)
 	LookUpListTweets(ctx context.Context, listID string, opt ...*ListTweetsOption) (*ListTweetsResponse, error)
 	ListMembers(ctx context.Context, listID string, opt ...*ListMembersOption) (*ListMembersResponse, error)
-	ListSpecifiedUser(ctx context.Context, userID string, opt ...*ListSpecifiedUserOption) (*ListSpecifiedUserResponse, error)
+	ListsSpecifiedUser(ctx context.Context, userID string, opt ...*ListsSpecifiedUserOption) (*ListsSpecifiedUserResponse, error)
 	LookUpListFollowers(ctx context.Context, listID string, opt ...*ListFollowersOption) (*ListFollowersResponse, error)
 	LookUpAllListsUserFollows(ctx context.Context, userID string, opt ...*ListFollowsOption) (*AllListsUserFollowsResponse, error)
 }
@@ -199,8 +199,8 @@ func (c *client) LookUpListTweets(ctx context.Context, listID string, opt ...*Li
 	return lookUpListTweets(ctx, c, listID, opt...)
 }
 
-func (c *client) ListSpecifiedUser(ctx context.Context, userID string, opt ...*ListSpecifiedUserOption) (*ListSpecifiedUserResponse, error) {
-	return listSpecifiedUser(ctx, c, userID, opt...)
+func (c *client) ListsSpecifiedUser(ctx context.Context, userID string, opt ...*ListsSpecifiedUserOption) (*ListsSpecifiedUserResponse, error) {
+	return listsSpecifiedUser(ctx, c, userID, opt...)
 }
 
 func (c *client) ListMembers(ctx context.Context, listid string, opt ...*ListMembersOption) (*ListMembersResponse, error) {

--- a/client.go
+++ b/client.go
@@ -57,7 +57,7 @@ type Lists interface {
 	LookUpAllListsOwned(ctx context.Context, userID string, opt ...*AllListsOwnedOption) (*AllListsOwnedResponse, error)
 	LookUpListTweets(ctx context.Context, listID string, opt ...*ListTweetsOption) (*ListTweetsResponse, error)
 	ListMembers(ctx context.Context, listID string, opt ...*ListMembersOption) (*ListMembersResponse, error)
-	ListSpecifiedUserMemberOf(ctx context.Context, userid string, opt ...*ListSpecifiedUserMemberOfOption) (*ListSpecifiedUserMemberOfResponse, error)
+	ListSpecifiedUser(ctx context.Context, userID string, opt ...*ListSpecifiedUserOption) (*ListSpecifiedUserResponse, error)
 	LookUpListFollowers(ctx context.Context, listID string, opt ...*ListFollowersOption) (*ListFollowersResponse, error)
 	LookUpAllListsUserFollows(ctx context.Context, userID string, opt ...*ListFollowsOption) (*AllListsUserFollowsResponse, error)
 }
@@ -199,8 +199,8 @@ func (c *client) LookUpListTweets(ctx context.Context, listID string, opt ...*Li
 	return lookUpListTweets(ctx, c, listID, opt...)
 }
 
-func (c *client) ListSpecifiedUserMemberOf(ctx context.Context, userid string, opt ...*ListSpecifiedUserMemberOfOption) (*ListSpecifiedUserMemberOfResponse, error) {
-	return listSpecifiedUserMemberOf(ctx, c, userid, opt...)
+func (c *client) ListSpecifiedUser(ctx context.Context, userid string, opt ...*ListSpecifiedUserOption) (*ListSpecifiedUserResponse, error) {
+	return listSpecifiedUser(ctx, c, userid, opt...)
 }
 
 func (c *client) ListMembers(ctx context.Context, listid string, opt ...*ListMembersOption) (*ListMembersResponse, error) {

--- a/client.go
+++ b/client.go
@@ -57,6 +57,7 @@ type Lists interface {
 	LookUpAllListsOwned(ctx context.Context, userID string, opt ...*AllListsOwnedOption) (*AllListsOwnedResponse, error)
 	LookUpListTweets(ctx context.Context, listID string, opt ...*ListTweetsOption) (*ListTweetsResponse, error)
 	ListMembers(ctx context.Context, listID string, opt ...*ListMembersOption) (*ListMembersResponse, error)
+	ListSpecifiedUserMemberOf(ctx context.Context, userid string, opt ...*ListSpecifiedUserMemberOfOption) (*ListSpecifiedUserMemberOfResponse, error)
 	LookUpListFollowers(ctx context.Context, listID string, opt ...*ListFollowersOption) (*ListFollowersResponse, error)
 	LookUpAllListsUserFollows(ctx context.Context, userID string, opt ...*ListFollowsOption) (*AllListsUserFollowsResponse, error)
 }
@@ -196,6 +197,10 @@ func (c *client) LookUpAllListsOwned(ctx context.Context, userID string, opt ...
 
 func (c *client) LookUpListTweets(ctx context.Context, listID string, opt ...*ListTweetsOption) (*ListTweetsResponse, error) {
 	return lookUpListTweets(ctx, c, listID, opt...)
+}
+
+func (c *client) ListSpecifiedUserMemberOf(ctx context.Context, userid string, opt ...*ListSpecifiedUserMemberOfOption) (*ListSpecifiedUserMemberOfResponse, error) {
+	return listSpecifiedUserMemberOf(ctx, c, userid, opt...)
 }
 
 func (c *client) ListMembers(ctx context.Context, listid string, opt ...*ListMembersOption) (*ListMembersResponse, error) {

--- a/client.go
+++ b/client.go
@@ -199,8 +199,8 @@ func (c *client) LookUpListTweets(ctx context.Context, listID string, opt ...*Li
 	return lookUpListTweets(ctx, c, listID, opt...)
 }
 
-func (c *client) ListSpecifiedUser(ctx context.Context, userid string, opt ...*ListSpecifiedUserOption) (*ListSpecifiedUserResponse, error) {
-	return listSpecifiedUser(ctx, c, userid, opt...)
+func (c *client) ListSpecifiedUser(ctx context.Context, userID string, opt ...*ListSpecifiedUserOption) (*ListSpecifiedUserResponse, error) {
+	return listSpecifiedUser(ctx, c, userID, opt...)
 }
 
 func (c *client) ListMembers(ctx context.Context, listid string, opt ...*ListMembersOption) (*ListMembersResponse, error) {

--- a/endpoint.go
+++ b/endpoint.go
@@ -38,7 +38,7 @@ const (
 	lookUpListURL                = "https://api.twitter.com/2/lists/%v"
 	lookUpAllListsOwnedURL       = "https://api.twitter.com/2/users/%v/owned_lists"
 	lookUpListTweetsURL          = "https://api.twitter.com/2/lists/%v/tweets"
-	listSpecifiedUserMemberOfURL = "https://api.twitter.com/2/users/%v/list_memberships"
+	listSpecifiedUserURL = "https://api.twitter.com/2/users/%v/list_memberships"
 	listMembersURL               = "https://api.twitter.com/2/lists/%v/members"
 	lookUpListFollowersURL       = "https://api.twitter.com/2/lists/%v/followers"
 	lookUpAllListsUserFollowsURL = "https://api.twitter.com/2/users/%v/followed_lists"

--- a/endpoint.go
+++ b/endpoint.go
@@ -38,7 +38,7 @@ const (
 	lookUpListURL                = "https://api.twitter.com/2/lists/%v"
 	lookUpAllListsOwnedURL       = "https://api.twitter.com/2/users/%v/owned_lists"
 	lookUpListTweetsURL          = "https://api.twitter.com/2/lists/%v/tweets"
-	listSpecifiedUserURL         = "https://api.twitter.com/2/users/%v/list_memberships"
+	listsSpecifiedUserURL        = "https://api.twitter.com/2/users/%v/list_memberships"
 	listMembersURL               = "https://api.twitter.com/2/lists/%v/members"
 	lookUpListFollowersURL       = "https://api.twitter.com/2/lists/%v/followers"
 	lookUpAllListsUserFollowsURL = "https://api.twitter.com/2/users/%v/followed_lists"

--- a/endpoint.go
+++ b/endpoint.go
@@ -38,7 +38,7 @@ const (
 	lookUpListURL                = "https://api.twitter.com/2/lists/%v"
 	lookUpAllListsOwnedURL       = "https://api.twitter.com/2/users/%v/owned_lists"
 	lookUpListTweetsURL          = "https://api.twitter.com/2/lists/%v/tweets"
-	listSpecifiedUserURL = "https://api.twitter.com/2/users/%v/list_memberships"
+	listSpecifiedUserURL         = "https://api.twitter.com/2/users/%v/list_memberships"
 	listMembersURL               = "https://api.twitter.com/2/lists/%v/members"
 	lookUpListFollowersURL       = "https://api.twitter.com/2/lists/%v/followers"
 	lookUpAllListsUserFollowsURL = "https://api.twitter.com/2/users/%v/followed_lists"

--- a/endpoint.go
+++ b/endpoint.go
@@ -38,6 +38,7 @@ const (
 	lookUpListURL                = "https://api.twitter.com/2/lists/%v"
 	lookUpAllListsOwnedURL       = "https://api.twitter.com/2/users/%v/owned_lists"
 	lookUpListTweetsURL          = "https://api.twitter.com/2/lists/%v/tweets"
+	listSpecifiedUserMemberOfURL = "https://api.twitter.com/2/users/%v/list_memberships"
 	listMembersURL               = "https://api.twitter.com/2/lists/%v/members"
 	lookUpListFollowersURL       = "https://api.twitter.com/2/lists/%v/followers"
 	lookUpAllListsUserFollowsURL = "https://api.twitter.com/2/users/%v/followed_lists"

--- a/example/list/listsusermember/main.go
+++ b/example/list/listsusermember/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sivchari/gotwtr"
+)
+
+func main() {
+	client := gotwtr.New("key")
+	lmr, err := client.ListSpecifiedUserMemberOf(context.Background(), "84839422")
+	if err != nil {
+		panic(err)
+	}
+	for _, lm := range lmr.Lists {
+		fmt.Println(lm)
+	}
+}

--- a/example/list/listsusermember/main.go
+++ b/example/list/listsusermember/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	client := gotwtr.New("key")
-	lmr, err := client.ListSpecifiedUserMemberOf(context.Background(), "84839422")
+	lmr, err := client.ListSpecifiedUser(context.Background(), "84839422")
 	if err != nil {
 		panic(err)
 	}

--- a/example/list/listsusermember/main.go
+++ b/example/list/listsusermember/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	client := gotwtr.New("key")
-	lmr, err := client.ListSpecifiedUser(context.Background(), "84839422")
+	lmr, err := client.ListsSpecifiedUser(context.Background(), "84839422")
 	if err != nil {
 		panic(err)
 	}

--- a/list.go
+++ b/list.go
@@ -92,7 +92,7 @@ type ListMembersResponse struct {
 	Type     string              `json:"type,omitempty"`
 }
 
-type ListSpecifiedUserResponse struct {
+type ListsSpecifiedUserResponse struct {
 	Lists    []*List             `json:"data"`
 	Includes *ListIncludes       `json:"includes,omitempty"`
 	Errors   []*APIResponseError `json:"errors,omitempty"`

--- a/list.go
+++ b/list.go
@@ -91,3 +91,13 @@ type ListMembersResponse struct {
 	Detail   string              `json:"detail,omitempty"`
 	Type     string              `json:"type,omitempty"`
 }
+
+type ListSpecifiedUserMemberOfResponse struct {
+	Lists    []*List             `json:"data,omitempty"`
+	Includes *ListIncludes       `json:"includes,omitempty"`
+	Errors   []*APIResponseError `json:"errors,omitempty"`
+	Meta     *ListMeta           `json:"meta,omitempty"`
+	Title    string              `json:"title,omitempty"`
+	Detail   string              `json:"detail,omitempty"`
+	Type     string              `json:"type,omitempty"`
+}

--- a/list.go
+++ b/list.go
@@ -92,11 +92,11 @@ type ListMembersResponse struct {
 	Type     string              `json:"type,omitempty"`
 }
 
-type ListSpecifiedUserMemberOfResponse struct {
-	Lists    []*List             `json:"data,omitempty"`
+type ListSpecifiedUserResponse struct {
+	Lists    []*List             `json:"data"`
 	Includes *ListIncludes       `json:"includes,omitempty"`
 	Errors   []*APIResponseError `json:"errors,omitempty"`
-	Meta     *ListMeta           `json:"meta,omitempty"`
+	Meta     *ListMeta           `json:"meta"`
 	Title    string              `json:"title,omitempty"`
 	Detail   string              `json:"detail,omitempty"`
 	Type     string              `json:"type,omitempty"`

--- a/list_members.go
+++ b/list_members.go
@@ -97,7 +97,7 @@ func listsSpecifiedUser(ctx context.Context, c *client, userID string, opt ...*L
 		lopt.MaxResults = defaultMaxResults
 	}
 	if lopt.MaxResults < minimumMaxResults || lopt.MaxResults > maximumMaxResults {
-		return nil, fmt.Errorf("ists specified user: max results must be between %d and %d", minimumMaxResults, maximumMaxResults)
+		return nil, fmt.Errorf("lists specified user: max results must be between %d and %d", minimumMaxResults, maximumMaxResults)
 	}
 	lopt.addQuery(req)
 

--- a/list_members.go
+++ b/list_members.go
@@ -65,12 +65,12 @@ func listMembers(ctx context.Context, c *client, listid string, opt ...*ListMemb
 	return &lmr, nil
 }
 
-func listSpecifiedUser(ctx context.Context, c *client, userID string, opt ...*ListSpecifiedUserOption) (*ListSpecifiedUserResponse, error) {
+func listsSpecifiedUser(ctx context.Context, c *client, userID string, opt ...*ListsSpecifiedUserOption) (*ListsSpecifiedUserResponse, error) {
 	if userID == "" {
 		return nil, errors.New("lists specified user: userID parameter is required")
 	}
 
-	lm := fmt.Sprintf(listSpecifiedUserURL, userID)
+	lm := fmt.Sprintf(listsSpecifiedUserURL, userID)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, lm, nil)
 	if err != nil {
@@ -79,7 +79,7 @@ func listSpecifiedUser(ctx context.Context, c *client, userID string, opt ...*Li
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.bearerToken))
 
-	var lopt ListSpecifiedUserOption
+	var lopt ListsSpecifiedUserOption
 	switch len(opt) {
 	case 0:
 		// do nothing
@@ -108,7 +108,7 @@ func listSpecifiedUser(ctx context.Context, c *client, userID string, opt ...*Li
 
 	defer resp.Body.Close()
 
-	var lmr ListSpecifiedUserResponse
+	var lmr ListsSpecifiedUserResponse
 	if err := json.NewDecoder(resp.Body).Decode(&lmr); err != nil {
 		return nil, fmt.Errorf("lists specified user: %w", err)
 	}

--- a/list_members.go
+++ b/list_members.go
@@ -74,7 +74,7 @@ func listSpecifiedUser(ctx context.Context, c *client, userID string, opt ...*Li
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, lm, nil)
 	if err != nil {
-		return nil, fmt.Errorf("lists specified user : %w", err)
+		return nil, fmt.Errorf("lists specified user: %w", err)
 	}
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.bearerToken))

--- a/list_members.go
+++ b/list_members.go
@@ -67,14 +67,14 @@ func listMembers(ctx context.Context, c *client, listid string, opt ...*ListMemb
 
 func listSpecifiedUser(ctx context.Context, c *client, userID string, opt ...*ListSpecifiedUserOption) (*ListSpecifiedUserResponse, error) {
 	if userID == "" {
-		return nil, errors.New("lists a specified user: userID parameter is required")
+		return nil, errors.New("lists specified user: userID parameter is required")
 	}
 
 	lm := fmt.Sprintf(listSpecifiedUserURL, userID)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, lm, nil)
 	if err != nil {
-		return nil, fmt.Errorf("lists a specified user is a member of: %w", err)
+		return nil, fmt.Errorf("lists specified user : %w", err)
 	}
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.bearerToken))
@@ -86,7 +86,7 @@ func listSpecifiedUser(ctx context.Context, c *client, userID string, opt ...*Li
 	case 1:
 		lopt = *opt[0]
 	default:
-		return nil, errors.New("lists a specified user is a member of: only one option is allowed")
+		return nil, errors.New("lists specified user: only one option is allowed")
 	}
 	const (
 		minimumMaxResults = 1
@@ -97,24 +97,24 @@ func listSpecifiedUser(ctx context.Context, c *client, userID string, opt ...*Li
 		lopt.MaxResults = defaultMaxResults
 	}
 	if lopt.MaxResults < minimumMaxResults || lopt.MaxResults > maximumMaxResults {
-		return nil, fmt.Errorf("ists a specified user is a member of: max results must be between %d and %d", minimumMaxResults, maximumMaxResults)
+		return nil, fmt.Errorf("ists specified user: max results must be between %d and %d", minimumMaxResults, maximumMaxResults)
 	}
 	lopt.addQuery(req)
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("lists a specified user is a member of: %w", err)
+		return nil, fmt.Errorf("lists specified user: %w", err)
 	}
 
 	defer resp.Body.Close()
 
 	var lmr ListSpecifiedUserResponse
 	if err := json.NewDecoder(resp.Body).Decode(&lmr); err != nil {
-		return nil, fmt.Errorf("lists a specified user is a member of: %w", err)
+		return nil, fmt.Errorf("lists specified user: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return &lmr, &HTTPError{
-			APIName: "lists a specified user is a member of",
+			APIName: "lists specified user",
 			Status:  resp.Status,
 			URL:     req.URL.String(),
 		}

--- a/list_members_test.go
+++ b/list_members_test.go
@@ -125,3 +125,232 @@ func Test_listMembers(t *testing.T) {
 		})
 	}
 }
+
+func Test_ListSpecifiedUserMemberOf(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		ctx    context.Context
+		client *http.Client
+		id     string
+		opt    []*gotwtr.ListSpecifiedUserMemberOfOption
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *gotwtr.ListSpecifiedUserMemberOfResponse
+		wantErr bool
+	}{
+		{
+			name: "200 ok default payload",
+			args: args{
+				ctx: context.Background(),
+				client: mockHTTPClient(func(request *http.Request) *http.Response {
+					data := `{
+						"data": [
+							   {
+							     "id": "1451951974291689472",
+							     "name": "Twitter"
+							   },
+							   {
+							     "id": "1451812298184540161",
+							     "name": "Updates"
+							   },
+							   {
+							     "id": "1450519480132509697",
+							     "name": "Twitter"
+							   }
+                        ],
+					    "meta": {
+							"result_count": 3
+						}
+					}`
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(data)),
+					}
+				}),
+				id:  "84839422",
+				opt: []*gotwtr.ListSpecifiedUserMemberOfOption{},
+			},
+			want: &gotwtr.ListSpecifiedUserMemberOfResponse{
+				Lists: []*gotwtr.List{
+					{
+						ID:   "1451951974291689472",
+						Name: "Twitter",
+					},
+					{
+						ID:   "1451812298184540161",
+						Name: "Updates",
+					},
+					{
+						ID:   "1450519480132509697",
+						Name: "Twitter",
+					},
+				},
+				Meta: &gotwtr.ListMeta{
+					ResultCount: 3,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "200 ok option",
+			args: args{
+				ctx: context.Background(),
+				client: mockHTTPClient(func(request *http.Request) *http.Response {
+					data := `{
+						"data": [
+							{
+								"follower_count": 5,
+								"id": "1451951974291689472",
+								"name": "Twitter",
+								"owner_id": "1227213680120479745"
+							}
+						],
+						"includes": {
+							"users": [
+								{
+									"name": "구돆",
+									"created_at": "2020-02-11T12:52:11.000Z",
+									"id": "1227213680120479745",
+									"username": "Follow__Y0U"
+								}
+							]
+						},
+						"meta": {
+							"result_count": 1
+						}
+					}`
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(data)),
+					}
+				}),
+				id:  "84839422",
+				opt: []*gotwtr.ListSpecifiedUserMemberOfOption{},
+			},
+			want: &gotwtr.ListSpecifiedUserMemberOfResponse{
+				Lists: []*gotwtr.List{
+					{
+						ID:            "1451951974291689472",
+						Name:          "Twitter",
+						FollowerCount: 5,
+						OwnerID:       "1227213680120479745",
+					},
+				},
+				Includes: &gotwtr.ListIncludes{
+					Users: []*gotwtr.User{
+						{
+							Name:      "구돆",
+							CreatedAt: "2020-02-11T12:52:11.000Z",
+							ID:        "1227213680120479745",
+							UserName:  "Follow__Y0U",
+						},
+					},
+				},
+				Meta: &gotwtr.ListMeta{
+					ResultCount: 1,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "User Not Found",
+			args: args{
+				ctx: context.Background(),
+				client: mockHTTPClient(func(request *http.Request) *http.Response {
+					data := `{
+						"errors":[
+							{
+								"value":"849422",
+								"detail":"Could not find user with id: [849422].",
+								"title":"Not Found Error",
+								"resource_type":"user",
+								"parameter":"id",
+								"resource_id":"849422",
+								"type":"https://api.twitter.com/2/problems/resource-not-found"
+							}
+						]
+					}`
+					return &http.Response{
+						StatusCode: http.StatusNotFound,
+						Body:       io.NopCloser(strings.NewReader(data)),
+					}
+				}),
+				id:  "849422",
+				opt: []*gotwtr.ListSpecifiedUserMemberOfOption{},
+			},
+			want: &gotwtr.ListSpecifiedUserMemberOfResponse{
+				Errors: []*gotwtr.APIResponseError{
+					{
+						Value:        "849422",
+						Detail:       "Could not find user with id: [849422].",
+						Title:        "Not Found Error",
+						ResourceType: "user",
+						Parameter:    "id",
+						ResourceID:   "849422",
+						Type:         "https://api.twitter.com/2/problems/resource-not-found",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid Request",
+			args: args{
+				ctx: context.Background(),
+				client: mockHTTPClient(func(request *http.Request) *http.Response {
+					data := `{
+						"errors":[
+							{
+								"parameters":{
+									"id": ["8488877666666666666666666666666622839422"]
+								},
+								"message":"The 'id' query parameter value [8488877666666666666666666666666622839422] is not valid"
+							}
+						],
+						"title":"Invalid Request",
+						"detail":"One or more parameters to your request was invalid.",
+						"type":"https://api.twitter.com/2/problems/invalid-request"
+					}`
+					return &http.Response{
+						StatusCode: http.StatusBadRequest,
+						Body:       io.NopCloser(strings.NewReader(data)),
+					}
+				}),
+				id:  "8488877666666666666666666666666622839422",
+				opt: []*gotwtr.ListSpecifiedUserMemberOfOption{},
+			},
+			want: &gotwtr.ListSpecifiedUserMemberOfResponse{
+				Errors: []*gotwtr.APIResponseError{
+					{
+						Parameters: gotwtr.Parameter{
+							ID: []string{"8488877666666666666666666666666622839422"},
+						},
+						Message: "The 'id' query parameter value [8488877666666666666666666666666622839422] is not valid",
+					},
+				},
+				Title:  "Invalid Request",
+				Detail: "One or more parameters to your request was invalid.",
+				Type:   "https://api.twitter.com/2/problems/invalid-request",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := gotwtr.New("test-key", gotwtr.WithHTTPClient(tt.args.client))
+			got, err := c.ListSpecifiedUserMemberOf(tt.args.ctx, tt.args.id, tt.args.opt...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("client.ListSpecifiedUserMemberOf() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("client.ListSpecifiedUserMemberOf() mismatch (-want +got):\n%s", diff)
+				return
+			}
+		})
+	}
+}

--- a/list_members_test.go
+++ b/list_members_test.go
@@ -133,12 +133,12 @@ func Test_ListSpecifiedUser(t *testing.T) {
 		ctx    context.Context
 		client *http.Client
 		id     string
-		opt    []*gotwtr.ListSpecifiedUserOption
+		opt    []*gotwtr.ListsSpecifiedUserOption
 	}
 	tests := []struct {
 		name    string
 		args    args
-		want    *gotwtr.ListSpecifiedUserResponse
+		want    *gotwtr.ListsSpecifiedUserResponse
 		wantErr bool
 	}{
 		{
@@ -171,9 +171,9 @@ func Test_ListSpecifiedUser(t *testing.T) {
 					}
 				}),
 				id:  "84839422",
-				opt: []*gotwtr.ListSpecifiedUserOption{},
+				opt: []*gotwtr.ListsSpecifiedUserOption{},
 			},
-			want: &gotwtr.ListSpecifiedUserResponse{
+			want: &gotwtr.ListsSpecifiedUserResponse{
 				Lists: []*gotwtr.List{
 					{
 						ID:   "1451951974291689472",
@@ -228,9 +228,9 @@ func Test_ListSpecifiedUser(t *testing.T) {
 					}
 				}),
 				id:  "84839422",
-				opt: []*gotwtr.ListSpecifiedUserOption{},
+				opt: []*gotwtr.ListsSpecifiedUserOption{},
 			},
-			want: &gotwtr.ListSpecifiedUserResponse{
+			want: &gotwtr.ListsSpecifiedUserResponse{
 				Lists: []*gotwtr.List{
 					{
 						ID:            "1451951974291689472",
@@ -279,9 +279,9 @@ func Test_ListSpecifiedUser(t *testing.T) {
 					}
 				}),
 				id:  "849422",
-				opt: []*gotwtr.ListSpecifiedUserOption{},
+				opt: []*gotwtr.ListsSpecifiedUserOption{},
 			},
-			want: &gotwtr.ListSpecifiedUserResponse{
+			want: &gotwtr.ListsSpecifiedUserResponse{
 				Errors: []*gotwtr.APIResponseError{
 					{
 						Value:        "849422",
@@ -320,9 +320,9 @@ func Test_ListSpecifiedUser(t *testing.T) {
 					}
 				}),
 				id:  "8488877666666666666666666666666622839422",
-				opt: []*gotwtr.ListSpecifiedUserOption{},
+				opt: []*gotwtr.ListsSpecifiedUserOption{},
 			},
-			want: &gotwtr.ListSpecifiedUserResponse{
+			want: &gotwtr.ListsSpecifiedUserResponse{
 				Errors: []*gotwtr.APIResponseError{
 					{
 						Parameters: gotwtr.Parameter{
@@ -343,7 +343,7 @@ func Test_ListSpecifiedUser(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := gotwtr.New("test-key", gotwtr.WithHTTPClient(tt.args.client))
-			got, err := c.ListSpecifiedUser(tt.args.ctx, tt.args.id, tt.args.opt...)
+			got, err := c.ListsSpecifiedUser(tt.args.ctx, tt.args.id, tt.args.opt...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("client.ListSpecifiedUser() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/list_members_test.go
+++ b/list_members_test.go
@@ -301,7 +301,6 @@ func Test_ListSpecifiedUserMemberOf(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				client: mockHTTPClient(func(request *http.Request) *http.Response {
-					id := "`id`"
 					data := fmt.Sprintf(`{
 						"errors":[
 							{
@@ -314,7 +313,7 @@ func Test_ListSpecifiedUserMemberOf(t *testing.T) {
 						"title":"Invalid Request",
 						"detail":"One or more parameters to your request was invalid.",
 						"type":"https://api.twitter.com/2/problems/invalid-request"
-					}`, id)
+					}`, "`id`")
 					return &http.Response{
 						StatusCode: http.StatusBadRequest,
 						Body:       io.NopCloser(strings.NewReader(data)),

--- a/list_members_test.go
+++ b/list_members_test.go
@@ -127,18 +127,18 @@ func Test_listMembers(t *testing.T) {
 	}
 }
 
-func Test_ListSpecifiedUserMemberOf(t *testing.T) {
+func Test_ListSpecifiedUser(t *testing.T) {
 	t.Parallel()
 	type args struct {
 		ctx    context.Context
 		client *http.Client
 		id     string
-		opt    []*gotwtr.ListSpecifiedUserMemberOfOption
+		opt    []*gotwtr.ListSpecifiedUserOption
 	}
 	tests := []struct {
 		name    string
 		args    args
-		want    *gotwtr.ListSpecifiedUserMemberOfResponse
+		want    *gotwtr.ListSpecifiedUserResponse
 		wantErr bool
 	}{
 		{
@@ -171,9 +171,9 @@ func Test_ListSpecifiedUserMemberOf(t *testing.T) {
 					}
 				}),
 				id:  "84839422",
-				opt: []*gotwtr.ListSpecifiedUserMemberOfOption{},
+				opt: []*gotwtr.ListSpecifiedUserOption{},
 			},
-			want: &gotwtr.ListSpecifiedUserMemberOfResponse{
+			want: &gotwtr.ListSpecifiedUserResponse{
 				Lists: []*gotwtr.List{
 					{
 						ID:   "1451951974291689472",
@@ -228,9 +228,9 @@ func Test_ListSpecifiedUserMemberOf(t *testing.T) {
 					}
 				}),
 				id:  "84839422",
-				opt: []*gotwtr.ListSpecifiedUserMemberOfOption{},
+				opt: []*gotwtr.ListSpecifiedUserOption{},
 			},
-			want: &gotwtr.ListSpecifiedUserMemberOfResponse{
+			want: &gotwtr.ListSpecifiedUserResponse{
 				Lists: []*gotwtr.List{
 					{
 						ID:            "1451951974291689472",
@@ -279,9 +279,9 @@ func Test_ListSpecifiedUserMemberOf(t *testing.T) {
 					}
 				}),
 				id:  "849422",
-				opt: []*gotwtr.ListSpecifiedUserMemberOfOption{},
+				opt: []*gotwtr.ListSpecifiedUserOption{},
 			},
-			want: &gotwtr.ListSpecifiedUserMemberOfResponse{
+			want: &gotwtr.ListSpecifiedUserResponse{
 				Errors: []*gotwtr.APIResponseError{
 					{
 						Value:        "849422",
@@ -320,9 +320,9 @@ func Test_ListSpecifiedUserMemberOf(t *testing.T) {
 					}
 				}),
 				id:  "8488877666666666666666666666666622839422",
-				opt: []*gotwtr.ListSpecifiedUserMemberOfOption{},
+				opt: []*gotwtr.ListSpecifiedUserOption{},
 			},
-			want: &gotwtr.ListSpecifiedUserMemberOfResponse{
+			want: &gotwtr.ListSpecifiedUserResponse{
 				Errors: []*gotwtr.APIResponseError{
 					{
 						Parameters: gotwtr.Parameter{
@@ -343,13 +343,13 @@ func Test_ListSpecifiedUserMemberOf(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := gotwtr.New("test-key", gotwtr.WithHTTPClient(tt.args.client))
-			got, err := c.ListSpecifiedUserMemberOf(tt.args.ctx, tt.args.id, tt.args.opt...)
+			got, err := c.ListSpecifiedUser(tt.args.ctx, tt.args.id, tt.args.opt...)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("client.ListSpecifiedUserMemberOf() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("client.ListSpecifiedUser() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("client.ListSpecifiedUserMemberOf() mismatch (-want +got):\n%s", diff)
+				t.Errorf("client.ListSpecifiedUser() mismatch (-want +got):\n%s", diff)
 				return
 			}
 		})

--- a/list_members_test.go
+++ b/list_members_test.go
@@ -2,6 +2,7 @@ package gotwtr_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -300,19 +301,20 @@ func Test_ListSpecifiedUserMemberOf(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				client: mockHTTPClient(func(request *http.Request) *http.Response {
-					data := `{
+					id := "`id`"
+					data := fmt.Sprintf(`{
 						"errors":[
 							{
 								"parameters":{
 									"id": ["8488877666666666666666666666666622839422"]
 								},
-								"message":"The 'id' query parameter value [8488877666666666666666666666666622839422] is not valid"
+								"message":"The %v query parameter value [8488877666666666666666666666666622839422] is not valid"
 							}
 						],
 						"title":"Invalid Request",
 						"detail":"One or more parameters to your request was invalid.",
 						"type":"https://api.twitter.com/2/problems/invalid-request"
-					}`
+					}`, id)
 					return &http.Response{
 						StatusCode: http.StatusBadRequest,
 						Body:       io.NopCloser(strings.NewReader(data)),
@@ -327,7 +329,7 @@ func Test_ListSpecifiedUserMemberOf(t *testing.T) {
 						Parameters: gotwtr.Parameter{
 							ID: []string{"8488877666666666666666666666666622839422"},
 						},
-						Message: "The 'id' query parameter value [8488877666666666666666666666666622839422] is not valid",
+						Message: "The `id` query parameter value [8488877666666666666666666666666622839422] is not valid",
 					},
 				},
 				Title:  "Invalid Request",

--- a/list_option.go
+++ b/list_option.go
@@ -178,7 +178,7 @@ func (l ListFollowersOption) addQuery(req *http.Request) {
 	}
 }
 
-type ListSpecifiedUserMemberOfOption struct {
+type ListSpecifiedUserOption struct {
 	Expansions      []Expansion
 	ListFields      []ListField
 	MaxResults      int
@@ -186,14 +186,16 @@ type ListSpecifiedUserMemberOfOption struct {
 	UserFields      []UserField
 }
 
-func (l *ListSpecifiedUserMemberOfOption) addQuery(req *http.Request) {
+func (l *ListSpecifiedUserOption) addQuery(req *http.Request) {
 	q := req.URL.Query()
 	if len(l.Expansions) > 0 {
+		/*
 		for _, expansion := range l.Expansions {
 			if expansion != "list.owner_id" {
 				panic("lists a specified user is a member of: Only owner_id is allowed")
 			}
 		}
+		*/
 		q.Add("expansions", strings.Join(expansionsToString(l.Expansions), ","))
 	}
 	if len(l.ListFields) > 0 {

--- a/list_option.go
+++ b/list_option.go
@@ -178,6 +178,41 @@ func (l ListFollowersOption) addQuery(req *http.Request) {
 	}
 }
 
+type ListSpecifiedUserMemberOfOption struct {
+	Expansions      []Expansion
+	ListFields      []ListField
+	MaxResults      int
+	PaginationToken string
+	UserFields      []UserField
+}
+
+func (l *ListSpecifiedUserMemberOfOption) addQuery(req *http.Request) {
+	q := req.URL.Query()
+	if len(l.Expansions) > 0 {
+		for _, expansion := range l.Expansions {
+			if expansion != "list.owner_id" {
+				panic("lists a specified user is a member of: Only owner_id is allowed")
+			}
+		}
+		q.Add("expansions", strings.Join(expansionsToString(l.Expansions), ","))
+	}
+	if len(l.ListFields) > 0 {
+		q.Add("tweet.fields", strings.Join(listFieldsToString(l.ListFields), "."))
+	}
+	if l.MaxResults > 0 {
+		q.Add("max_results", strconv.Itoa(l.MaxResults))
+	}
+	if l.PaginationToken != "" {
+		q.Add("pagination_token", l.PaginationToken)
+	}
+	if len(l.UserFields) > 0 && len(l.Expansions) > 0 {
+		q.Add("user.fields", strings.Join(userFieldsToString(l.UserFields), ","))
+	}
+	if len(q) > 0 {
+		req.URL.RawQuery = q.Encode()
+	}
+}
+
 func listFieldsToString(lfs []ListField) []string {
 	slice := make([]string, len(lfs))
 	for i, lf := range lfs {

--- a/list_option.go
+++ b/list_option.go
@@ -189,13 +189,6 @@ type ListSpecifiedUserOption struct {
 func (l *ListSpecifiedUserOption) addQuery(req *http.Request) {
 	q := req.URL.Query()
 	if len(l.Expansions) > 0 {
-		/*
-		for _, expansion := range l.Expansions {
-			if expansion != "list.owner_id" {
-				panic("lists a specified user is a member of: Only owner_id is allowed")
-			}
-		}
-		*/
 		q.Add("expansions", strings.Join(expansionsToString(l.Expansions), ","))
 	}
 	if len(l.ListFields) > 0 {

--- a/list_option.go
+++ b/list_option.go
@@ -178,7 +178,7 @@ func (l ListFollowersOption) addQuery(req *http.Request) {
 	}
 }
 
-type ListSpecifiedUserOption struct {
+type ListsSpecifiedUserOption struct {
 	Expansions      []Expansion
 	ListFields      []ListField
 	MaxResults      int
@@ -186,7 +186,7 @@ type ListSpecifiedUserOption struct {
 	UserFields      []UserField
 }
 
-func (l *ListSpecifiedUserOption) addQuery(req *http.Request) {
+func (l *ListsSpecifiedUserOption) addQuery(req *http.Request) {
 	q := req.URL.Query()
 	if len(l.Expansions) > 0 {
 		q.Add("expansions", strings.Join(expansionsToString(l.Expansions), ","))


### PR DESCRIPTION
it relates #81

Note

- At https://github.com/senk8/gotwtr/blob/ret-all-lists-specified-user-member/list_members_test.go#L309 ,
`'id'` was `` `id` ``in the original response.  Do you know of a way to include`` ` ` `` in`` ` ` ``? 