### PR TITLE
enable full search

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,6 +28,7 @@ type Tweets interface {
 	RetweetsLookup(ctx context.Context, tweetID string, opt ...*RetweetsLookupOption) (*RetweetsResponse, error)
 	TweetsUserLiked(ctx context.Context, userID string, opt ...*TweetsUserLikedOpts) (*TweetsUserLikedResponse, error)
 	UsersLikingTweet(ctx context.Context, tweetID string, opt ...*UsersLikingTweetOption) (*UsersLikingTweetResponse, error)
+	SearchAllTweets(ctx context.Context, tweet string, opt ...*SearchTweetsOption) (*SearchTweetsResponse, error)
 }
 
 type Users interface {
@@ -124,6 +125,12 @@ func (c *Client) UserTweetTimeline(ctx context.Context, userID string, opt ...*U
 // SearchRecentTweets returns Tweets from the last seven days that match a search query.
 func (c *Client) SearchRecentTweets(ctx context.Context, tweet string, opt ...*SearchTweetsOption) (*SearchTweetsResponse, error) {
 	return searchRecentTweets(ctx, c.client, tweet, opt...)
+}
+
+// SearchAllTweets returns Tweets since the first Tweet was created on March 26, 2006.
+// This endpoint is only available to those users who have been approved for Academic Research access.
+func (c *client) SearchAllTweets(ctx context.Context, tweet string, opt ...*SearchTweetsOption) (*SearchTweetsResponse, error) {
+	return searchAllTweets(ctx, c, tweet, opt...)
 }
 
 // CountsRecentTweet returns count of Tweets from the last seven days that match a query.

--- a/endpoint.go
+++ b/endpoint.go
@@ -15,6 +15,7 @@ const (
 	retweetsLookupURL         = "https://api.twitter.com/2/tweets/%v/retweeted_by"
 	usersLikingTweetURL       = "https://api.twitter.com/2/tweets/%v/liking_users"
 	tweetsUserLikedURL        = "https://api.twitter.com/2/users/%v/liked_tweets"
+	searchAllTweetsURL        = "https://api.twitter.com/2/tweets/search/all?query=%v"
 )
 
 const (

--- a/search_tweet.go
+++ b/search_tweet.go
@@ -66,3 +66,62 @@ func searchRecentTweets(ctx context.Context, c *client, tweet string, opt ...*Se
 
 	return &str, nil
 }
+
+func searchAllTweets(ctx context.Context, c *client, tweet string, opt ...*SearchTweetsOption) (*SearchTweetsResponse, error) {
+	switch {
+	case tweet == "":
+		return nil, errors.New("search all tweets: tweet parameter is required")
+	case len(tweet) > searchTweetMaxQueryLength:
+		return nil, errors.New("search all tweets: tweet parameter must be less than or equal to 512 characters")
+	}
+
+	ep := fmt.Sprintf(searchAllTweetsURL, tweet)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ep, nil)
+	if err != nil {
+		return nil, fmt.Errorf("search all tweets new request with ctx: %w", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.bearerToken))
+
+	var sopt SearchTweetsOption
+	switch len(opt) {
+	case 0:
+		// do nothing
+	case 1:
+		sopt = *opt[0]
+	default:
+		return nil, errors.New("search all tweets: only one option is allowed")
+	}
+	const (
+		minimumMaxResults = 10
+		maximumMaxResults = 500
+		defaultMaxResults = 10
+	)
+	if sopt.MaxResults == 0 {
+		sopt.MaxResults = defaultMaxResults
+	}
+	if sopt.MaxResults < minimumMaxResults || sopt.MaxResults > maximumMaxResults {
+		return nil, fmt.Errorf("search all tweets: max results must be between %d and %d", minimumMaxResults, maximumMaxResults)
+	}
+	sopt.addQuery(req)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("search all tweets: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var str SearchTweetsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&str); err != nil {
+		return nil, fmt.Errorf("search all tweets: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return &str, &HTTPError{
+			APIName: "search all tweets",
+			Status:  resp.Status,
+			URL:     req.URL.String(),
+		}
+	}
+
+	return &str, nil
+}

--- a/search_tweet_test.go
+++ b/search_tweet_test.go
@@ -159,3 +159,164 @@ func Test_searchRecentTweets(t *testing.T) {
 		})
 	}
 }
+
+func Test_searchAllTweets(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		ctx    context.Context
+		client *http.Client
+		query  string
+		opt    []*gotwtr.SearchTweetsOption
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *gotwtr.SearchTweetsResponse
+		wantErr bool
+	}{
+		{
+			name: "200 ok default payload",
+			args: args{
+				ctx: context.Background(),
+				client: mockHTTPClient(func(request *http.Request) *http.Response {
+					body := `{
+						"data": [
+							{
+								"id": "1444834989024202755",
+								"text": "RT @_ShamGod: This is most \"affordable housing\" deals in luxury buildings. Most of the  ones in NYC housing connect won't let you access th…"
+							},
+							{
+								"id": "1444834986008457217",
+								"text": "Harry en NYC - Octubre 3 #LoveOnTourNewYork #LOTNewYork #LOTNewYorkN1 https://t.co/up6J75RSpP"
+							},
+							{
+								"id": "1444834985135927296",
+								"text": "RT @ABC7: New statue of #GeorgeFloyd vandalized with paint in NYC; suspect flees on skateboard\nhttps://t.co/zTG1vvkG1b"
+							},
+							{
+								"id": "1444834983231868930",
+								"text": "RT @BTB_MikeII: 100 YEARS AGO AT THE POLO GROUNDS 10/3/1921: New York's Managers Plant Their League Championship Flags... https://t.co/SR69…"
+							},
+							{
+								"id": "1444834982023901189",
+								"text": "Why am I not surprised ? When you have parents teaching their children to be #Racists … allegedly and systematic Racism is rampant! #NYC #TEACHING #PARENTS #SchoolStrike2021 #NYCDOE #QUEENS #GeorgeFloyd #Homeschool #Teachers #nyc #GENTRIFICATION #Progressives https://t.co/PiPaL70dqG"
+							},
+							{
+								"id": "1444834981579087873",
+								"text": "RT @amyjharris: NEW INVESTIGATION: As homelessness has spiked in New York City, the people who run nonprofit shelters have found ways to en…"
+							},
+							{
+								"id": "1444834976848039941",
+								"text": "RT @EllenBarkin: Well done NYC!"
+							},
+							{
+								"id": "1444834976143273986",
+								"text": "RT @hernameiskayIa: Nyc and la shows always win idc"
+							},
+							{
+								"id": "1444834975883407361",
+								"text": "go✍️ to✍️ a✍️ harry✍️ nyc✍️ show✍️"
+							},
+							{
+								"id": "1444834974646116359",
+								"text": "RT @elhammohamud: girlies be like nyc is not ready for us like nyc has never seen 10 harry styles fans in head to toe shein walking around…"
+							}
+						],
+						"meta": {
+							"newest_id": "1444834989024202755",
+							"oldest_id": "1444834974646116359",
+							"result_count": 10,
+							"next_token": "b26v89c19zqg8o3fpds7phdmycbzydb96f7kaqov4kuwt"
+						}
+					}`
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(body)),
+					}
+				}),
+				query: "nyc",
+				opt:   []*gotwtr.SearchTweetsOption{},
+			},
+			want: &gotwtr.SearchTweetsResponse{
+				Tweets: []*gotwtr.Tweet{
+					{
+						ID:   "1444834989024202755",
+						Text: "RT @_ShamGod: This is most \"affordable housing\" deals in luxury buildings. Most of the  ones in NYC housing connect won't let you access th…",
+					},
+					{
+						ID:   "1444834986008457217",
+						Text: "Harry en NYC - Octubre 3 #LoveOnTourNewYork #LOTNewYork #LOTNewYorkN1 https://t.co/up6J75RSpP",
+					},
+					{
+						ID:   "1444834985135927296",
+						Text: "RT @ABC7: New statue of #GeorgeFloyd vandalized with paint in NYC; suspect flees on skateboard\nhttps://t.co/zTG1vvkG1b",
+					},
+					{
+						ID:   "1444834983231868930",
+						Text: "RT @BTB_MikeII: 100 YEARS AGO AT THE POLO GROUNDS 10/3/1921: New York's Managers Plant Their League Championship Flags... https://t.co/SR69…",
+					},
+					{
+						ID:   "1444834982023901189",
+						Text: "Why am I not surprised ? When you have parents teaching their children to be #Racists … allegedly and systematic Racism is rampant! #NYC #TEACHING #PARENTS #SchoolStrike2021 #NYCDOE #QUEENS #GeorgeFloyd #Homeschool #Teachers #nyc #GENTRIFICATION #Progressives https://t.co/PiPaL70dqG",
+					},
+					{
+						ID:   "1444834981579087873",
+						Text: "RT @amyjharris: NEW INVESTIGATION: As homelessness has spiked in New York City, the people who run nonprofit shelters have found ways to en…",
+					},
+					{
+						ID:   "1444834976848039941",
+						Text: "RT @EllenBarkin: Well done NYC!",
+					},
+					{
+						ID:   "1444834976143273986",
+						Text: "RT @hernameiskayIa: Nyc and la shows always win idc",
+					},
+					{
+						ID:   "1444834975883407361",
+						Text: "go✍️ to✍️ a✍️ harry✍️ nyc✍️ show✍️",
+					},
+					{
+						ID:   "1444834974646116359",
+						Text: "RT @elhammohamud: girlies be like nyc is not ready for us like nyc has never seen 10 harry styles fans in head to toe shein walking around…",
+					},
+				},
+				Meta: &gotwtr.SearchTweetsMeta{
+					NewestID:    "1444834989024202755",
+					OldestID:    "1444834974646116359",
+					ResultCount: 10,
+					NextToken:   "b26v89c19zqg8o3fpds7phdmycbzydb96f7kaqov4kuwt",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid case empty query",
+			args: args{
+				ctx:    context.Background(),
+				client: nil,
+				query:  "",
+				opt:    []*gotwtr.SearchTweetsOption{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		// TODO: Add test cases with request fieds (tweet, user, etc.)
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := gotwtr.New("test-key", gotwtr.WithHTTPClient(tt.args.client))
+			got, err := c.SearchAllTweets(tt.args.ctx, tt.args.query, tt.args.opt...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("client.SearchAllTweets() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("client.SearchAllTweets() mismatch (-want +got):\n%s", diff)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implement the [tweets/search/all](https://developer.twitter.com/en/docs/twitter-api/tweets/search/api-reference/get-tweets-search-all) endpoint that is only available to users who have been approved for [Academic Research access](https://developer.twitter.com/en/docs/twitter-api/getting-started/about-twitter-api#v2-access-level).