### PR TITLE
Close the HTTP connection when stops a stream

### DIFF
--- a/filtered_stream.go
+++ b/filtered_stream.go
@@ -113,6 +113,7 @@ func retrieveStreamRules(ctx context.Context, c *client, opt ...*RetrieveStreamR
 
 func (s *ConnectToStream) Stop() {
 	close(s.done)
+	s.cancel()
 	s.wg.Wait()
 }
 
@@ -148,6 +149,7 @@ func (s *ConnectToStream) retry(req *http.Request) {
 }
 
 func connectToStream(ctx context.Context, c *client, ch chan<- ConnectToStreamResponse, errCh chan<- error, opt ...*ConnectToStreamOption) *ConnectToStream {
+	ctx, cancel := context.WithCancel(ctx)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, connectToStreamURL, nil)
 	if err != nil {
 		errCh <- fmt.Errorf("connect to stream new request with ctx: %w", err)
@@ -171,6 +173,7 @@ func connectToStream(ctx context.Context, c *client, ch chan<- ConnectToStreamRe
 		ch:     ch,
 		done:   make(chan struct{}),
 		wg:     &sync.WaitGroup{},
+		cancel: cancel,
 	}
 
 	s.wg.Add(1)

--- a/tweet.go
+++ b/tweet.go
@@ -1,6 +1,7 @@
 package gotwtr
 
 import (
+	"context"
 	"net/http"
 	"sync"
 )
@@ -322,6 +323,7 @@ type ConnectToStream struct {
 	ch     chan<- ConnectToStreamResponse
 	done   chan struct{}
 	wg     *sync.WaitGroup
+	cancel context.CancelFunc
 }
 
 type PostRetweetResponse struct {


### PR DESCRIPTION
ConnectToStream.Stop() waits for the next item from the stream.
Therefore, this will be blocked and will not be returned immediately.

Without this change, the library user will also have to close the HTTP connection if they want to stop the stream immediately.

```go
	// ... (snip) ...
	ctx, cancel := context.WithCancel(context.Background())
	stream := client.ConnectToStream(ctx, ch, errCh, &option)
	defer stream.Stop()
	defer cancel()
	// ... (snip) ...
```

If this is expected behavior, please close this PR.  Sorry.