### PR TITLE
period to comma debug

### DIFF
--- a/list_option.go
+++ b/list_option.go
@@ -18,7 +18,7 @@ func (l LookUpListOption) addQuery(req *http.Request) {
 		q.Add("expansions", strings.Join(expansionsToString(l.Expansions), ","))
 	}
 	if len(l.ListFields) > 0 {
-		q.Add("list.fields", strings.Join(listFieldsToString(l.ListFields), "."))
+		q.Add("list.fields", strings.Join(listFieldsToString(l.ListFields), ","))
 	}
 	if len(l.UserFields) > 0 {
 		q.Add("user.fields", strings.Join(userFieldsToString(l.UserFields), ","))
@@ -42,7 +42,7 @@ func (a AllListsOwnedOption) addQuery(req *http.Request) {
 		q.Add("expansions", strings.Join(expansionsToString(a.Expansions), ","))
 	}
 	if len(a.ListFields) > 0 {
-		q.Add("list.fields", strings.Join(listFieldsToString(a.ListFields), "."))
+		q.Add("list.fields", strings.Join(listFieldsToString(a.ListFields), ","))
 	}
 	if a.MaxResults > 0 {
 		q.Add("max_results", strconv.Itoa(a.MaxResults))
@@ -78,7 +78,7 @@ func (l ListTweetsOption) addQuery(req *http.Request) {
 		q.Add("pagination_token", l.PaginationToken)
 	}
 	if len(l.TweetFields) > 0 {
-		q.Add("tweet.fields", strings.Join(tweetFieldsToString(l.TweetFields), "."))
+		q.Add("tweet.fields", strings.Join(tweetFieldsToString(l.TweetFields), ","))
 	}
 	if len(l.UserFields) > 0 {
 		q.Add("user.fields", strings.Join(userFieldsToString(l.UserFields), ","))
@@ -108,7 +108,7 @@ func (l ListMembersOption) addQuery(req *http.Request) {
 		q.Add("pagination_token", l.PaginationToken)
 	}
 	if len(l.TweetFields) > 0 {
-		q.Add("tweet.fields", strings.Join(tweetFieldsToString(l.TweetFields), "."))
+		q.Add("tweet.fields", strings.Join(tweetFieldsToString(l.TweetFields), ","))
 	}
 	if len(l.UserFields) > 0 {
 		q.Add("user.fields", strings.Join(userFieldsToString(l.UserFields), ","))
@@ -132,7 +132,7 @@ func (l ListFollowsOption) addQuery(req *http.Request) {
 		q.Add("expansions", strings.Join(expansionsToString(l.Expansions), ","))
 	}
 	if len(l.ListFields) > 0 {
-		q.Add("list.fields", strings.Join(listFieldsToString(l.ListFields), "."))
+		q.Add("list.fields", strings.Join(listFieldsToString(l.ListFields), ","))
 	}
 	if l.MaxResults > 0 {
 		q.Add("max_results", strconv.Itoa(l.MaxResults))
@@ -168,7 +168,7 @@ func (l ListFollowersOption) addQuery(req *http.Request) {
 		q.Add("pagination_token", l.PaginationToken)
 	}
 	if len(l.TweetFields) > 0 {
-		q.Add("tweet.fields", strings.Join(tweetFieldsToString(l.TweetFields), "."))
+		q.Add("tweet.fields", strings.Join(tweetFieldsToString(l.TweetFields), ","))
 	}
 	if len(l.UserFields) > 0 {
 		q.Add("user.fields", strings.Join(userFieldsToString(l.UserFields), ","))
@@ -192,7 +192,7 @@ func (l *ListsSpecifiedUserOption) addQuery(req *http.Request) {
 		q.Add("expansions", strings.Join(expansionsToString(l.Expansions), ","))
 	}
 	if len(l.ListFields) > 0 {
-		q.Add("tweet.fields", strings.Join(listFieldsToString(l.ListFields), "."))
+		q.Add("tweet.fields", strings.Join(listFieldsToString(l.ListFields), ","))
 	}
 	if l.MaxResults > 0 {
 		q.Add("max_results", strconv.Itoa(l.MaxResults))
@@ -220,7 +220,7 @@ func (l *PinnedListsOption) addQuery(req *http.Request) {
 		q.Add("expansions", strings.Join(expansionsToString(l.Expansions), ","))
 	}
 	if len(l.ListFields) > 0 {
-		q.Add("tweet.fields", strings.Join(listFieldsToString(l.ListFields), "."))
+		q.Add("tweet.fields", strings.Join(listFieldsToString(l.ListFields), ","))
 	}
 	if len(l.UserFields) > 0 && len(l.Expansions) > 0 {
 		q.Add("user.fields", strings.Join(userFieldsToString(l.UserFields), ","))


### PR DESCRIPTION
q.Add  strings.Joinの第二引数は "," ではないでしょうか。リストタイムライン取得できなかったのでここに辿り着きました。
look up list tweets: 400 Bad Request https://api.twitter.com/2/lists/17916342/tweets?expansions=referenced_tweets.id.author_id&max_results=20&tweet.fields=referenced_tweets.in_reply_to_user_id

curl を使ってみると、
"message":"The `tweet.fields` query parameter value [referenced_tweets.in_reply_to_user_id] is not one of
[attachments,
..
in_reply_to_user_id,
...
referenced_tweets,
..
withheld]"}],
カンマで区切られるところがピリオドでつながっています。
