### PR TITLE
fix: filtered stream silence stop due to io eof

### DIFF
--- a/filtered_stream.go
+++ b/filtered_stream.go
@@ -138,10 +138,10 @@ func (s *ConnectToStream) retry(req *http.Request) {
 		var connectToStream ConnectToStreamResponse
 		err := dec.Decode(&connectToStream)
 		if err != nil {
+			s.errCh <- err
 			if err == io.EOF {
 				break
 			}
-			s.errCh <- err
 		}
 		s.ch <- connectToStream
 	}


### PR DESCRIPTION
I used filtered stream for about a few weeks, and found that I often suddenly did not receive tweets, and after troubleshooting, I found that the loop quit after encountering the error of io eof, but did not notify the external caller through err chan (the external caller can only use err chan to determine whether it needs to reconnect)