### PR TITLE
Make postTweet response include errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -34,3 +34,12 @@ type Parameter struct {
 	UserName  []string `json:"username"`
 	UserNames []string `json:"usernames"`
 }
+
+type PostTweetResponseError struct {
+	Parameters PostTweetResponseErrorParameter `json:"parameters"`
+	Message    string                          `json:"message"`
+}
+
+type PostTweetResponseErrorParameter struct {
+	Text []string `json:"text"`
+}

--- a/manage_tweet_test.go
+++ b/manage_tweet_test.go
@@ -2,6 +2,7 @@ package gotwtr_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -54,6 +55,47 @@ func Test_postTweet(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "400 bad request payload",
+			args: args{
+				ctx: context.Background(),
+				client: mockHTTPClient(func(request *http.Request) *http.Response {
+					body := fmt.Sprintf(`
+												{
+														"errors": [{
+																"parameters": { 
+																		"text": ["%s"]
+																},
+																"message": "The Tweet contains an invalid URL."
+														}],
+														"title": "Invalid Request",
+														"detail": "One or more parameters to your request was invalid.",
+														"type": "https://api.twitter.com/2/problems/invalid-request"
+												}
+                    `, strings.Repeat("x", 281))
+					return &http.Response{
+						StatusCode: http.StatusBadRequest,
+						Body:       io.NopCloser(strings.NewReader(body)),
+					}
+				}),
+				body: &gotwtr.PostTweetOption{
+					Text: strings.Repeat("x", 281),
+				},
+			},
+			want: &gotwtr.PostTweetResponse{
+				Errors: []*gotwtr.PostTweetResponseError{{
+					Parameters: gotwtr.PostTweetResponseErrorParameter{
+						Text: []string{strings.Repeat("x", 281)},
+					},
+					Message: "The Tweet contains an invalid URL.",
+				},
+				},
+				Title:  "Invalid Request",
+				Detail: "One or more parameters to your request was invalid.",
+				Type:   "https://api.twitter.com/2/problems/invalid-request",
+			},
+			wantErr: true,
 		},
 	}
 	for i, tt := range tests {

--- a/tweet.go
+++ b/tweet.go
@@ -626,7 +626,11 @@ type TweetReply struct {
 }
 
 type PostTweetResponse struct {
-	PostTweetData PostTweetData `json:"data"`
+	PostTweetData PostTweetData             `json:"data"`
+	Errors        []*PostTweetResponseError `json:"errors,omitempty"`
+	Title         string                    `json:"title,omitempty"`
+	Detail        string                    `json:"detail,omitempty"`
+	Type          string                    `json:"type,omitempty"`
 }
 
 type PostTweetData struct {


### PR DESCRIPTION
Post tweet doesn't return the full response when the request is not successful. I added details from Twitter API's response to the returned object.