### PR TITLE
feat: implement OAuth2 Token Invalidation endpoint (POST /oauth2/inva…

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ const (
 
 type OAuth interface {
 	GenerateAppOnlyBearerToken(ctx context.Context) (bool, error)
-	// TODO: oauth2/invalidate_token
+	InvalidateToken(ctx context.Context) (*InvalidateTokenResponse, error)
 }
 
 type Tweets interface {
@@ -201,8 +201,13 @@ func New(bearerToken string, opts ...ClientOption) *Client {
 }
 
 // GenerateAppOnlyBearerToken generates a bearer token for app-only auth.
-func (c *client) GenerateAppOnlyBearerToken(ctx context.Context) (bool, error) {
-	return generateAppOnlyBearerToken(ctx, c)
+func (c *Client) GenerateAppOnlyBearerToken(ctx context.Context) (bool, error) {
+	return generateAppOnlyBearerToken(ctx, c.client)
+}
+
+// InvalidateToken invalidates the current bearer token.
+func (c *Client) InvalidateToken(ctx context.Context) (*InvalidateTokenResponse, error) {
+	return c.client.InvalidateToken(ctx)
 }
 
 // RetrieveMultipleTweets returns a variety of information about the Tweet specified by the requested ID or list of IDs.

--- a/endpoint.go
+++ b/endpoint.go
@@ -3,7 +3,7 @@ package gotwtr
 // EndpointURL is the base URL for the Twitter V2 API.
 const (
 	generateAppOnlyBearerTokenURL = "https://api.twitter.com/oauth2/token?grant_type=client_credentials"
-	// TODO: oauth2/invalidate_token
+	invalidateTokenURL            = "https://api.twitter.com/oauth2/invalidate_token"
 )
 
 const (


### PR DESCRIPTION
…lidate_token)

- Added invalidateTokenURL endpoint constant
- Added InvalidateToken method to OAuth interface
- Implemented InvalidateTokenResponse structure
- Implemented InvalidateToken function with proper error handling
- Clears bearer token from client upon successful invalidation
- Added comprehensive tests for token invalidation
- Fixed GenerateAppOnlyBearerToken to use Client receiver for consistency

close #201