### PR TITLE
feat: implement Spaces Tweets endpoint (GET /2/spaces/:id/tweets)

### DIFF
--- a/client.go
+++ b/client.go
@@ -93,7 +93,8 @@ type Spaces interface {
 	LookUpSpaces(ctx context.Context, spaceIDs []string, opt ...*SpaceOption) (*SpacesResponse, error)
 	LookUpSpace(ctx context.Context, spaceID string, opt ...*SpaceOption) (*SpaceResponse, error)
 	UsersPurchasedSpaceTicket(ctx context.Context, spaceID string, opt ...*UsersPurchasedSpaceTicketOption) (*UsersPurchasedSpaceTicketResponse, error)
-	// TODO: /2/spaces/:id/tweets
+	// Spaces tweets
+	SpacesTweets(ctx context.Context, spaceID string, opt ...*SpacesTweetsOption) (*SpacesTweetsResponse, error)
 	DiscoverSpaces(ctx context.Context, userIDs []string, opt ...*DiscoverSpacesOption) (*DiscoverSpacesResponse, error)
 }
 
@@ -595,4 +596,9 @@ func (c *Client) LookUpDM(ctx context.Context, dmConversationID string, opt ...*
 // Supports retrieving events from the previous 30 days.
 func (c *Client) LookUpAllDM(ctx context.Context, opt ...*DirectMessageOption) (*LookUpAllDMResponse, error) {
 	return lookUpAllDM(ctx, c.client, opt...)
+}
+
+// SpacesTweets returns Tweets shared in the specified Space.
+func (c *Client) SpacesTweets(ctx context.Context, spaceID string, opt ...*SpacesTweetsOption) (*SpacesTweetsResponse, error) {
+	return spacesTweets(ctx, c.client, spaceID, opt...)
 }

--- a/endpoint.go
+++ b/endpoint.go
@@ -78,6 +78,8 @@ const (
 	spacesURL                    = "https://api.twitter.com/2/spaces?ids="
 	usersPurchasedSpaceTicketURL = "https://api.twitter.com/2/spaces/%v/buyers"
 	discoverSpacesURL            = "https://api.twitter.com/2/spaces/by/creator_ids?user_ids="
+	// Spaces tweets
+	spacesTweetsURL = "https://api.twitter.com/2/spaces/%v/tweets"
 	// Search Spaces
 	searchSpacesURL = "https://api.twitter.com/2/spaces/search"
 )

--- a/space.go
+++ b/space.go
@@ -112,3 +112,17 @@ type UsersPurchasedSpaceTicketResponse struct {
 type LookUpUsersWhoPurchasedSpaceTicketIncludes struct {
 	Tweets []*Tweet
 }
+
+type SpacesTweetsResponse struct {
+	Tweets   []*Tweet            `json:"data"`
+	Includes *TweetIncludes      `json:"includes,omitempty"`
+	Errors   []*APIResponseError `json:"errors,omitempty"`
+	Meta     *SpacesTweetsMeta   `json:"meta,omitempty"`
+	Title    string              `json:"title,omitempty"`
+	Detail   string              `json:"detail,omitempty"`
+	Type     string              `json:"type,omitempty"`
+}
+
+type SpacesTweetsMeta struct {
+	ResultCount int `json:"result_count,omitempty"`
+}

--- a/space_option.go
+++ b/space_option.go
@@ -137,3 +137,25 @@ func (u *UsersPurchasedSpaceTicketOption) addQuery(req *http.Request) {
 		req.URL.RawQuery = q.Encode()
 	}
 }
+
+type SpacesTweetsOption struct {
+	Expansions  []Expansion
+	TweetFields []TweetField
+	UserFields  []UserField
+}
+
+func (s *SpacesTweetsOption) addQuery(req *http.Request) {
+	q := req.URL.Query()
+	if len(s.Expansions) > 0 {
+		q.Add("expansions", strings.Join(expansionsToString(s.Expansions), ","))
+	}
+	if len(s.TweetFields) > 0 {
+		q.Add("tweet.fields", strings.Join(tweetFieldsToString(s.TweetFields), ","))
+	}
+	if len(s.UserFields) > 0 {
+		q.Add("user.fields", strings.Join(userFieldsToString(s.UserFields), ","))
+	}
+	if len(q) > 0 {
+		req.URL.RawQuery = q.Encode()
+	}
+}


### PR DESCRIPTION
- Added spacesTweetsURL endpoint constant
- Added SpacesTweets method to Spaces interface
- Added SpacesTweetsOption struct with query parameter handling
- Added SpacesTweetsResponse and SpacesTweetsMeta structs
- Implemented spacesTweets function in space_lookup.go with proper error handling
- Added SpacesTweets client method to client.go
- Added comprehensive tests including success, error, and validation cases

close #199