### PR TITLE
feat: implement Community Notes API endpoints

### DIFF
--- a/client.go
+++ b/client.go
@@ -141,6 +141,13 @@ type DirectMessages interface {
 	LookUpAllDM(ctx context.Context, opt ...*DirectMessageOption) (*LookUpAllDMResponse, error)
 }
 
+type CommunityNotes interface {
+	// Community Notes
+	SearchPostsEligibleForNotes(ctx context.Context, opt ...*SearchPostsEligibleForNotesOption) (*SearchPostsEligibleForNotesResponse, error)
+	SearchNotesWritten(ctx context.Context, opt ...*SearchNotesWrittenOption) (*SearchNotesWrittenResponse, error)
+	CreateCommunityNote(ctx context.Context, body *CreateCommunityNoteBody) (*CreateCommunityNoteResponse, error)
+}
+
 // Twtr is a main interface for all Twitter API calls.
 type Twtr interface {
 	OAuth
@@ -150,6 +157,7 @@ type Twtr interface {
 	Lists
 	Compliances
 	DirectMessages
+	CommunityNotes
 }
 
 type client struct {
@@ -606,4 +614,19 @@ func (c *Client) LookUpAllDM(ctx context.Context, opt ...*DirectMessageOption) (
 // SpacesTweets returns Tweets shared in the specified Space.
 func (c *Client) SpacesTweets(ctx context.Context, spaceID string, opt ...*SpacesTweetsOption) (*SpacesTweetsResponse, error) {
 	return spacesTweets(ctx, c.client, spaceID, opt...)
+}
+
+// SearchPostsEligibleForNotes returns a list of posts that are eligible to receive a Community Note.
+func (c *Client) SearchPostsEligibleForNotes(ctx context.Context, opt ...*SearchPostsEligibleForNotesOption) (*SearchPostsEligibleForNotesResponse, error) {
+	return searchPostsEligibleForNotes(ctx, c.client, opt...)
+}
+
+// SearchNotesWritten returns a list of Community Notes written by the authenticating user.
+func (c *Client) SearchNotesWritten(ctx context.Context, opt ...*SearchNotesWrittenOption) (*SearchNotesWrittenResponse, error) {
+	return searchNotesWritten(ctx, c.client, opt...)
+}
+
+// CreateCommunityNote creates a Community Note on a post.
+func (c *Client) CreateCommunityNote(ctx context.Context, body *CreateCommunityNoteBody) (*CreateCommunityNoteResponse, error) {
+	return createCommunityNote(ctx, c.client, body)
 }

--- a/community_notes.go
+++ b/community_notes.go
@@ -1,0 +1,110 @@
+package gotwtr
+
+// Community Notes field enum for request parameters
+type CommunityNoteField string
+
+const (
+	CommunityNoteFieldID                  CommunityNoteField = "id"
+	CommunityNoteFieldText                CommunityNoteField = "text"
+	CommunityNoteFieldCreatedAt           CommunityNoteField = "created_at"
+	CommunityNoteFieldAuthorID            CommunityNoteField = "author_id"
+	CommunityNoteFieldPostID              CommunityNoteField = "post_id"
+	CommunityNoteFieldClassification      CommunityNoteField = "classification"
+	CommunityNoteFieldBelievable          CommunityNoteField = "believable"
+	CommunityNoteFieldHarmful             CommunityNoteField = "harmful"
+	CommunityNoteFieldValidationDifficult CommunityNoteField = "validation_difficult"
+	CommunityNoteFieldMisleadingOther     CommunityNoteField = "misleading_other"
+	CommunityNoteFieldNotMisleading       CommunityNoteField = "not_misleading"
+)
+
+// CommunityNote represents a Community Note structure
+type CommunityNote struct {
+	ID                     string   `json:"id"`
+	Text                   string   `json:"text"`
+	CreatedAt              string   `json:"created_at,omitempty"`
+	AuthorID               string   `json:"author_id,omitempty"`
+	PostID                 string   `json:"post_id,omitempty"`
+	Classification         string   `json:"classification,omitempty"`
+	Believable             *bool    `json:"believable,omitempty"`
+	Harmful                *bool    `json:"harmful,omitempty"`
+	ValidationDifficult    *bool    `json:"validation_difficult,omitempty"`
+	MisleadingOther        *bool    `json:"misleading_other,omitempty"`
+	NotMisleading          *bool    `json:"not_misleading,omitempty"`
+	TrustworthySources     []string `json:"trustworthy_sources,omitempty"`
+}
+
+// Post represents a post/tweet eligible for Community Notes
+type Post struct {
+	ID        string `json:"id"`
+	Text      string `json:"text"`
+	AuthorID  string `json:"author_id,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+}
+
+// CommunityNotesIncludes represents included data in Community Notes responses
+type CommunityNotesIncludes struct {
+	Users []*User  `json:"users,omitempty"`
+	Posts []*Post  `json:"posts,omitempty"`
+	Notes []*CommunityNote `json:"notes,omitempty"`
+}
+
+// SearchPostsEligibleForNotesResponse represents the response for searching posts eligible for notes
+type SearchPostsEligibleForNotesResponse struct {
+	Data     []*Post                 `json:"data,omitempty"`
+	Includes *CommunityNotesIncludes `json:"includes,omitempty"`
+	Meta     *SearchNotesMeta        `json:"meta,omitempty"`
+	Errors   []*APIResponseError     `json:"errors,omitempty"`
+	Title    string                  `json:"title,omitempty"`
+	Detail   string                  `json:"detail,omitempty"`
+	Type     string                  `json:"type,omitempty"`
+}
+
+// SearchNotesWrittenResponse represents the response for searching notes written by user
+type SearchNotesWrittenResponse struct {
+	Data     []*CommunityNote        `json:"data,omitempty"`
+	Includes *CommunityNotesIncludes `json:"includes,omitempty"`
+	Meta     *SearchNotesMeta        `json:"meta,omitempty"`
+	Errors   []*APIResponseError     `json:"errors,omitempty"`
+	Title    string                  `json:"title,omitempty"`
+	Detail   string                  `json:"detail,omitempty"`
+	Type     string                  `json:"type,omitempty"`
+}
+
+// CreateCommunityNoteResponse represents the response for creating a community note
+type CreateCommunityNoteResponse struct {
+	Data   *CommunityNote          `json:"data,omitempty"`
+	Errors []*APIResponseError     `json:"errors,omitempty"`
+	Title  string                  `json:"title,omitempty"`
+	Detail string                  `json:"detail,omitempty"`
+	Type   string                  `json:"type,omitempty"`
+}
+
+// SearchNotesMeta represents metadata for search responses
+type SearchNotesMeta struct {
+	ResultCount   int    `json:"result_count,omitempty"`
+	NextToken     string `json:"next_token,omitempty"`
+	PreviousToken string `json:"previous_token,omitempty"`
+}
+
+// CreateCommunityNoteBody represents the request body for creating a community note
+type CreateCommunityNoteBody struct {
+	TestMode bool                       `json:"test_mode"`
+	PostID   string                     `json:"post_id"`
+	Info     *CommunityNoteInfoRequest  `json:"info"`
+}
+
+// CommunityNoteInfoRequest represents the info section of a create note request
+type CommunityNoteInfoRequest struct {
+	Text               string   `json:"text"`
+	Classification     string   `json:"classification"`
+	MisleadingTags     []string `json:"misleading_tags,omitempty"`
+	TrustworthySources []string `json:"trustworthy_sources,omitempty"`
+}
+
+func communityNoteFieldsToString(fields []CommunityNoteField) []string {
+	slice := make([]string, len(fields))
+	for i, field := range fields {
+		slice[i] = string(field)
+	}
+	return slice
+}

--- a/community_notes_lookup.go
+++ b/community_notes_lookup.go
@@ -1,0 +1,148 @@
+package gotwtr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+func searchPostsEligibleForNotes(ctx context.Context, c *client, opt ...*SearchPostsEligibleForNotesOption) (*SearchPostsEligibleForNotesResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, searchPostsEligibleForNotesURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("search posts eligible for notes new request with ctx: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.bearerToken))
+
+	var sopt SearchPostsEligibleForNotesOption
+	switch len(opt) {
+	case 0:
+		// Set default test_mode = true
+		sopt.TestMode = true
+	case 1:
+		sopt = *opt[0]
+		sopt.TestMode = true // Ensure test_mode is always true
+	default:
+		return nil, errors.New("search posts eligible for notes: only one option is allowed")
+	}
+	sopt.addQuery(req)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("search posts eligible for notes response: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	var spr SearchPostsEligibleForNotesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&spr); err != nil {
+		return nil, fmt.Errorf("search posts eligible for notes decode: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return &spr, &HTTPError{
+			APIName: "search posts eligible for notes",
+			Status:  resp.Status,
+			URL:     req.URL.String(),
+		}
+	}
+
+	return &spr, nil
+}
+
+func searchNotesWritten(ctx context.Context, c *client, opt ...*SearchNotesWrittenOption) (*SearchNotesWrittenResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, searchNotesWrittenURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("search notes written new request with ctx: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.bearerToken))
+
+	var sopt SearchNotesWrittenOption
+	switch len(opt) {
+	case 0:
+		// Set default test_mode = true
+		sopt.TestMode = true
+	case 1:
+		sopt = *opt[0]
+		sopt.TestMode = true // Ensure test_mode is always true
+	default:
+		return nil, errors.New("search notes written: only one option is allowed")
+	}
+	sopt.addQuery(req)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("search notes written response: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	var snr SearchNotesWrittenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&snr); err != nil {
+		return nil, fmt.Errorf("search notes written decode: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return &snr, &HTTPError{
+			APIName: "search notes written",
+			Status:  resp.Status,
+			URL:     req.URL.String(),
+		}
+	}
+
+	return &snr, nil
+}
+
+func createCommunityNote(ctx context.Context, c *client, body *CreateCommunityNoteBody) (*CreateCommunityNoteResponse, error) {
+	if body == nil {
+		return nil, errors.New("create community note: body parameter is required")
+	}
+	if body.PostID == "" {
+		return nil, errors.New("create community note: post_id is required")
+	}
+	if body.Info == nil {
+		return nil, errors.New("create community note: info is required")
+	}
+
+	// Ensure test_mode is always true
+	body.TestMode = true
+
+	j, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("create community note json marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, createCommunityNoteURL, bytes.NewReader(j))
+	if err != nil {
+		return nil, fmt.Errorf("create community note new request with ctx: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.bearerToken))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("create community note response: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	var cnr CreateCommunityNoteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&cnr); err != nil {
+		return nil, fmt.Errorf("create community note decode: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return &cnr, &HTTPError{
+			APIName: "create community note",
+			Status:  resp.Status,
+			URL:     req.URL.String(),
+		}
+	}
+
+	return &cnr, nil
+}

--- a/community_notes_option.go
+++ b/community_notes_option.go
@@ -1,0 +1,99 @@
+package gotwtr
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// SearchPostsEligibleForNotesOption represents options for searching posts eligible for notes
+type SearchPostsEligibleForNotesOption struct {
+	TestMode      bool                   `json:"test_mode"`
+	MaxResults    int                    `json:"max_results,omitempty"`
+	PaginationToken string               `json:"pagination_token,omitempty"`
+	Expansions    []Expansion            `json:"expansions,omitempty"`
+	NoteFields    []CommunityNoteField   `json:"note.fields,omitempty"`
+	PostFields    []TweetField           `json:"post.fields,omitempty"`
+	UserFields    []UserField            `json:"user.fields,omitempty"`
+}
+
+func (s *SearchPostsEligibleForNotesOption) addQuery(req *http.Request) {
+	q := req.URL.Query()
+	
+	// test_mode is required
+	q.Add("test_mode", "true")
+	
+	if s.MaxResults > 0 {
+		q.Add("max_results", strconv.Itoa(s.MaxResults))
+	}
+	
+	if s.PaginationToken != "" {
+		q.Add("pagination_token", s.PaginationToken)
+	}
+	
+	if len(s.Expansions) > 0 {
+		q.Add("expansions", strings.Join(expansionsToString(s.Expansions), ","))
+	}
+	
+	if len(s.NoteFields) > 0 {
+		q.Add("note.fields", strings.Join(communityNoteFieldsToString(s.NoteFields), ","))
+	}
+	
+	if len(s.PostFields) > 0 {
+		q.Add("post.fields", strings.Join(tweetFieldsToString(s.PostFields), ","))
+	}
+	
+	if len(s.UserFields) > 0 {
+		q.Add("user.fields", strings.Join(userFieldsToString(s.UserFields), ","))
+	}
+	
+	if len(q) > 0 {
+		req.URL.RawQuery = q.Encode()
+	}
+}
+
+// SearchNotesWrittenOption represents options for searching notes written by user
+type SearchNotesWrittenOption struct {
+	TestMode        bool                 `json:"test_mode"`
+	MaxResults      int                  `json:"max_results,omitempty"`
+	PaginationToken string               `json:"pagination_token,omitempty"`
+	Expansions      []Expansion          `json:"expansions,omitempty"`
+	NoteFields      []CommunityNoteField `json:"note.fields,omitempty"`
+	PostFields      []TweetField         `json:"post.fields,omitempty"`
+	UserFields      []UserField          `json:"user.fields,omitempty"`
+}
+
+func (s *SearchNotesWrittenOption) addQuery(req *http.Request) {
+	q := req.URL.Query()
+	
+	// test_mode is required
+	q.Add("test_mode", "true")
+	
+	if s.MaxResults > 0 {
+		q.Add("max_results", strconv.Itoa(s.MaxResults))
+	}
+	
+	if s.PaginationToken != "" {
+		q.Add("pagination_token", s.PaginationToken)
+	}
+	
+	if len(s.Expansions) > 0 {
+		q.Add("expansions", strings.Join(expansionsToString(s.Expansions), ","))
+	}
+	
+	if len(s.NoteFields) > 0 {
+		q.Add("note.fields", strings.Join(communityNoteFieldsToString(s.NoteFields), ","))
+	}
+	
+	if len(s.PostFields) > 0 {
+		q.Add("post.fields", strings.Join(tweetFieldsToString(s.PostFields), ","))
+	}
+	
+	if len(s.UserFields) > 0 {
+		q.Add("user.fields", strings.Join(userFieldsToString(s.UserFields), ","))
+	}
+	
+	if len(q) > 0 {
+		req.URL.RawQuery = q.Encode()
+	}
+}

--- a/community_notes_test.go
+++ b/community_notes_test.go
@@ -1,0 +1,290 @@
+package gotwtr_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sivchari/gotwtr"
+)
+
+func Test_searchPostsEligibleForNotes(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		ctx    context.Context
+		client *http.Client
+		opt    []*gotwtr.SearchPostsEligibleForNotesOption
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *gotwtr.SearchPostsEligibleForNotesResponse
+		wantErr bool
+	}{
+		{
+			name: "200 ok the request was successful",
+			args: args{
+				ctx: context.Background(),
+				client: mockHTTPClient(func(request *http.Request) *http.Response {
+					data := `{
+						"data": [
+							{
+								"id": "1234567890",
+								"text": "This is a sample post eligible for Community Notes",
+								"author_id": "987654321"
+							}
+						],
+						"meta": {
+							"result_count": 1
+						}
+					}`
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(data)),
+					}
+				}),
+				opt: []*gotwtr.SearchPostsEligibleForNotesOption{
+					{
+						MaxResults: 10,
+					},
+				},
+			},
+			want: &gotwtr.SearchPostsEligibleForNotesResponse{
+				Data: []*gotwtr.Post{
+					{
+						ID:       "1234567890",
+						Text:     "This is a sample post eligible for Community Notes",
+						AuthorID: "987654321",
+					},
+				},
+				Meta: &gotwtr.SearchNotesMeta{
+					ResultCount: 1,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "404 not found",
+			args: args{
+				ctx: context.Background(),
+				client: mockHTTPClient(func(request *http.Request) *http.Response {
+					data := `{
+						"title": "Not Found Error",
+						"detail": "The requested resource was not found.",
+						"type": "https://api.x.com/2/problems/resource-not-found"
+					}`
+					return &http.Response{
+						StatusCode: http.StatusNotFound,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(data)),
+					}
+				}),
+			},
+			want: &gotwtr.SearchPostsEligibleForNotesResponse{
+				Title:  "Not Found Error",
+				Detail: "The requested resource was not found.",
+				Type:   "https://api.x.com/2/problems/resource-not-found",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := gotwtr.New("key", gotwtr.WithHTTPClient(tt.args.client))
+			got, err := c.SearchPostsEligibleForNotes(tt.args.ctx, tt.args.opt...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("client.SearchPostsEligibleForNotes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("client.SearchPostsEligibleForNotes() mismatch (-want +got):\n%s", diff)
+				return
+			}
+		})
+	}
+}
+
+func Test_searchNotesWritten(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		ctx    context.Context
+		client *http.Client
+		opt    []*gotwtr.SearchNotesWrittenOption
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *gotwtr.SearchNotesWrittenResponse
+		wantErr bool
+	}{
+		{
+			name: "200 ok the request was successful",
+			args: args{
+				ctx: context.Background(),
+				client: mockHTTPClient(func(request *http.Request) *http.Response {
+					data := `{
+						"data": [
+							{
+								"id": "note123",
+								"text": "This claim needs more context...",
+								"author_id": "user123",
+								"post_id": "1234567890",
+								"classification": "needs_more_context"
+							}
+						],
+						"meta": {
+							"result_count": 1
+						}
+					}`
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(data)),
+					}
+				}),
+				opt: []*gotwtr.SearchNotesWrittenOption{
+					{
+						MaxResults: 10,
+					},
+				},
+			},
+			want: &gotwtr.SearchNotesWrittenResponse{
+				Data: []*gotwtr.CommunityNote{
+					{
+						ID:             "note123",
+						Text:           "This claim needs more context...",
+						AuthorID:       "user123",
+						PostID:         "1234567890",
+						Classification: "needs_more_context",
+					},
+				},
+				Meta: &gotwtr.SearchNotesMeta{
+					ResultCount: 1,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := gotwtr.New("key", gotwtr.WithHTTPClient(tt.args.client))
+			got, err := c.SearchNotesWritten(tt.args.ctx, tt.args.opt...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("client.SearchNotesWritten() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("client.SearchNotesWritten() mismatch (-want +got):\n%s", diff)
+				return
+			}
+		})
+	}
+}
+
+func Test_createCommunityNote(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		ctx    context.Context
+		client *http.Client
+		body   *gotwtr.CreateCommunityNoteBody
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *gotwtr.CreateCommunityNoteResponse
+		wantErr bool
+	}{
+		{
+			name: "201 created successfully",
+			args: args{
+				ctx: context.Background(),
+				client: mockHTTPClient(func(request *http.Request) *http.Response {
+					data := `{
+						"data": {
+							"id": "note456",
+							"text": "This post needs additional context to be understood correctly.",
+							"author_id": "user123",
+							"post_id": "1234567890",
+							"classification": "needs_more_context"
+						}
+					}`
+					return &http.Response{
+						StatusCode: http.StatusCreated,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(data)),
+					}
+				}),
+				body: &gotwtr.CreateCommunityNoteBody{
+					TestMode: true,
+					PostID:   "1234567890",
+					Info: &gotwtr.CommunityNoteInfoRequest{
+						Text:           "This post needs additional context to be understood correctly.",
+						Classification: "needs_more_context",
+					},
+				},
+			},
+			want: &gotwtr.CreateCommunityNoteResponse{
+				Data: &gotwtr.CommunityNote{
+					ID:             "note456",
+					Text:           "This post needs additional context to be understood correctly.",
+					AuthorID:       "user123",
+					PostID:         "1234567890",
+					Classification: "needs_more_context",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing body",
+			args: args{
+				ctx:    context.Background(),
+				client: http.DefaultClient,
+				body:   nil,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "missing post_id",
+			args: args{
+				ctx:    context.Background(),
+				client: http.DefaultClient,
+				body: &gotwtr.CreateCommunityNoteBody{
+					TestMode: true,
+					PostID:   "",
+					Info: &gotwtr.CommunityNoteInfoRequest{
+						Text:           "This post needs additional context.",
+						Classification: "needs_more_context",
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := gotwtr.New("key", gotwtr.WithHTTPClient(tt.args.client))
+			got, err := c.CreateCommunityNote(tt.args.ctx, tt.args.body)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("client.CreateCommunityNote() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("client.CreateCommunityNote() mismatch (-want +got):\n%s", diff)
+				return
+			}
+		})
+	}
+}

--- a/endpoint.go
+++ b/endpoint.go
@@ -131,3 +131,10 @@ const (
 	lookUpDMURL            = "https://api.twitter.com/2/dm_conversations/%v/dm_events"
 	lookUpAllDMURL         = "https://api.twitter.com/2/dm_events"
 )
+
+const (
+	// Community Notes
+	searchPostsEligibleForNotesURL = "https://api.x.com/2/notes/search/posts_eligible_for_notes"
+	searchNotesWrittenURL          = "https://api.x.com/2/notes/search/notes_written"
+	createCommunityNoteURL         = "https://api.x.com/2/notes"
+)


### PR DESCRIPTION
- Added Community Notes endpoints to endpoint.go
- Added CommunityNotes interface to client.go
- Created community_notes.go with data structures for Community Notes
- Created community_notes_option.go with request option types
- Created community_notes_lookup.go with implementation functions
- Added client methods for all Community Notes endpoints
- Added comprehensive tests covering success and error cases

Implements three Community Notes endpoints:
- GET /2/notes/search/posts_eligible_for_notes
- GET /2/notes/search/notes_written
- POST /2/notes

Resolves Issue #204