### PR TITLE
feat: implement DM Blocks management API endpoints

### DIFF
--- a/client.go
+++ b/client.go
@@ -140,6 +140,9 @@ type DirectMessages interface {
 	LookUpAllOneToOneDM(ctx context.Context, participantID string, opt ...*DirectMessageOption) (*LookUpAllOneToOneDMResponse, error)
 	LookUpDM(ctx context.Context, dmConversationID string, opt ...*DirectMessageOption) (*LookUpDMResponse, error)
 	LookUpAllDM(ctx context.Context, opt ...*DirectMessageOption) (*LookUpAllDMResponse, error)
+	// DM Blocks
+	PostDMBlocking(ctx context.Context, userID string, targetUserID string) (*PostDMBlockingResponse, error)
+	UndoDMBlocking(ctx context.Context, userID string, targetUserID string) (*UndoDMBlockingResponse, error)
 }
 
 type CommunityNotes interface {
@@ -676,4 +679,14 @@ func (c *Client) FinalizeChunkedUpload(ctx context.Context, req *MediaUploadFina
 // CheckUploadStatus checks the processing status of an uploaded media file.
 func (c *Client) CheckUploadStatus(ctx context.Context, req *MediaUploadStatusRequest) (*MediaUploadResponse, error) {
 	return checkUploadStatus(ctx, c.client, req)
+}
+
+// PostDMBlocking blocks DMs from a specific user.
+func (c *Client) PostDMBlocking(ctx context.Context, userID string, targetUserID string) (*PostDMBlockingResponse, error) {
+	return postDMBlocking(ctx, c.client, userID, targetUserID)
+}
+
+// UndoDMBlocking unblocks DMs from a specific user.
+func (c *Client) UndoDMBlocking(ctx context.Context, userID string, targetUserID string) (*UndoDMBlockingResponse, error) {
+	return undoDMBlocking(ctx, c.client, userID, targetUserID)
 }

--- a/direct_message.go
+++ b/direct_message.go
@@ -119,3 +119,31 @@ type LookUpAllDMResponse struct {
 	Detail  string              `json:"detail,omitempty"`
 	Type    string              `json:"type,omitempty"`
 }
+
+// DMBlocking represents the DM blocking data
+type DMBlocking struct {
+	DMBlocking bool `json:"dm_blocking"`
+}
+
+// PostDMBlockingResponse represents the response for blocking DMs from a user
+type PostDMBlockingResponse struct {
+	DMBlocking *DMBlocking         `json:"data,omitempty"`
+	Errors     []*APIResponseError `json:"errors,omitempty"`
+	Title      string              `json:"title,omitempty"`
+	Detail     string              `json:"detail,omitempty"`
+	Type       string              `json:"type,omitempty"`
+}
+
+// UndoDMBlockingResponse represents the response for unblocking DMs from a user
+type UndoDMBlockingResponse struct {
+	DMBlocking *DMBlocking         `json:"data,omitempty"`
+	Errors     []*APIResponseError `json:"errors,omitempty"`
+	Title      string              `json:"title,omitempty"`
+	Detail     string              `json:"detail,omitempty"`
+	Type       string              `json:"type,omitempty"`
+}
+
+// DMBlockingBody represents the request body for DM blocking operations
+type DMBlockingBody struct {
+	TargetUserID string `json:"target_user_id"`
+}

--- a/dm_blocks.go
+++ b/dm_blocks.go
@@ -1,0 +1,110 @@
+package gotwtr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+func postDMBlocking(ctx context.Context, c *client, userID string, targetUserID string) (*PostDMBlockingResponse, error) {
+	if userID == "" {
+		return nil, errors.New("post dm blocking: userID parameter is required")
+	}
+	if targetUserID == "" {
+		return nil, errors.New("post dm blocking: targetUserID parameter is required")
+	}
+
+	ep := fmt.Sprintf(postDMBlockingURL, userID)
+
+	body := &DMBlockingBody{
+		TargetUserID: targetUserID,
+	}
+
+	j, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("post dm blocking json marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ep, bytes.NewReader(j))
+	if err != nil {
+		return nil, fmt.Errorf("post dm blocking new request with ctx: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.bearerToken))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("post dm blocking response: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	var pdbr PostDMBlockingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&pdbr); err != nil {
+		return nil, fmt.Errorf("post dm blocking decode: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return &pdbr, &HTTPError{
+			APIName: "post dm blocking",
+			Status:  resp.Status,
+			URL:     req.URL.String(),
+		}
+	}
+
+	return &pdbr, nil
+}
+
+func undoDMBlocking(ctx context.Context, c *client, userID string, targetUserID string) (*UndoDMBlockingResponse, error) {
+	if userID == "" {
+		return nil, errors.New("undo dm blocking: userID parameter is required")
+	}
+	if targetUserID == "" {
+		return nil, errors.New("undo dm blocking: targetUserID parameter is required")
+	}
+
+	ep := fmt.Sprintf(undoDMBlockingURL, userID)
+
+	body := &DMBlockingBody{
+		TargetUserID: targetUserID,
+	}
+
+	j, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("undo dm blocking json marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, ep, bytes.NewReader(j))
+	if err != nil {
+		return nil, fmt.Errorf("undo dm blocking new request with ctx: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.bearerToken))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("undo dm blocking response: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	var udbr UndoDMBlockingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&udbr); err != nil {
+		return nil, fmt.Errorf("undo dm blocking decode: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return &udbr, &HTTPError{
+			APIName: "undo dm blocking",
+			Status:  resp.Status,
+			URL:     req.URL.String(),
+		}
+	}
+
+	return &udbr, nil
+}

--- a/dm_blocks_test.go
+++ b/dm_blocks_test.go
@@ -1,0 +1,253 @@
+package gotwtr_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sivchari/gotwtr"
+)
+
+func Test_postDMBlocking(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		ctx          context.Context
+		client       *http.Client
+		userID       string
+		targetUserID string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *gotwtr.PostDMBlockingResponse
+		wantErr bool
+	}{
+		{
+			name: "200 ok dm blocking successful",
+			args: args{
+				ctx:          context.Background(),
+				userID:       "123456789",
+				targetUserID: "987654321",
+				client: mockHTTPClient(func(request *http.Request) *http.Response {
+					data := `{
+						"data": {
+							"dm_blocking": true
+						}
+					}`
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(data)),
+					}
+				}),
+			},
+			want: &gotwtr.PostDMBlockingResponse{
+				DMBlocking: &gotwtr.DMBlocking{
+					DMBlocking: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "400 bad request - already blocked",
+			args: args{
+				ctx:          context.Background(),
+				userID:       "123456789",
+				targetUserID: "987654321",
+				client: mockHTTPClient(func(request *http.Request) *http.Response {
+					data := `{
+						"title": "Bad Request",
+						"detail": "User is already blocked for DMs",
+						"type": "https://api.twitter.com/2/problems/invalid-request"
+					}`
+					return &http.Response{
+						StatusCode: http.StatusBadRequest,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(data)),
+					}
+				}),
+			},
+			want: &gotwtr.PostDMBlockingResponse{
+				Title:  "Bad Request",
+				Detail: "User is already blocked for DMs",
+				Type:   "https://api.twitter.com/2/problems/invalid-request",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty userID",
+			args: args{
+				ctx:          context.Background(),
+				userID:       "",
+				targetUserID: "987654321",
+				client:       http.DefaultClient,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "empty targetUserID",
+			args: args{
+				ctx:          context.Background(),
+				userID:       "123456789",
+				targetUserID: "",
+				client:       http.DefaultClient,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := gotwtr.New("key", gotwtr.WithHTTPClient(tt.args.client))
+			got, err := c.PostDMBlocking(tt.args.ctx, tt.args.userID, tt.args.targetUserID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("client.PostDMBlocking() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("client.PostDMBlocking() mismatch (-want +got):\n%s", diff)
+				return
+			}
+		})
+	}
+}
+
+func Test_undoDMBlocking(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		ctx          context.Context
+		client       *http.Client
+		userID       string
+		targetUserID string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *gotwtr.UndoDMBlockingResponse
+		wantErr bool
+	}{
+		{
+			name: "200 ok dm unblocking successful",
+			args: args{
+				ctx:          context.Background(),
+				userID:       "123456789",
+				targetUserID: "987654321",
+				client: mockHTTPClient(func(request *http.Request) *http.Response {
+					data := `{
+						"data": {
+							"dm_blocking": false
+						}
+					}`
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(data)),
+					}
+				}),
+			},
+			want: &gotwtr.UndoDMBlockingResponse{
+				DMBlocking: &gotwtr.DMBlocking{
+					DMBlocking: false,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "400 bad request - not blocked",
+			args: args{
+				ctx:          context.Background(),
+				userID:       "123456789",
+				targetUserID: "987654321",
+				client: mockHTTPClient(func(request *http.Request) *http.Response {
+					data := `{
+						"title": "Bad Request",
+						"detail": "User is not blocked for DMs",
+						"type": "https://api.twitter.com/2/problems/invalid-request"
+					}`
+					return &http.Response{
+						StatusCode: http.StatusBadRequest,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(data)),
+					}
+				}),
+			},
+			want: &gotwtr.UndoDMBlockingResponse{
+				Title:  "Bad Request",
+				Detail: "User is not blocked for DMs",
+				Type:   "https://api.twitter.com/2/problems/invalid-request",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty userID",
+			args: args{
+				ctx:          context.Background(),
+				userID:       "",
+				targetUserID: "987654321",
+				client:       http.DefaultClient,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "empty targetUserID",
+			args: args{
+				ctx:          context.Background(),
+				userID:       "123456789",
+				targetUserID: "",
+				client:       http.DefaultClient,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "404 not found - invalid user",
+			args: args{
+				ctx:          context.Background(),
+				userID:       "123456789",
+				targetUserID: "invalid_user",
+				client: mockHTTPClient(func(request *http.Request) *http.Response {
+					data := `{
+						"title": "Not Found Error",
+						"detail": "Could not find user with id: [invalid_user].",
+						"type": "https://api.twitter.com/2/problems/resource-not-found"
+					}`
+					return &http.Response{
+						StatusCode: http.StatusNotFound,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(data)),
+					}
+				}),
+			},
+			want: &gotwtr.UndoDMBlockingResponse{
+				Title:  "Not Found Error",
+				Detail: "Could not find user with id: [invalid_user].",
+				Type:   "https://api.twitter.com/2/problems/resource-not-found",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := gotwtr.New("key", gotwtr.WithHTTPClient(tt.args.client))
+			got, err := c.UndoDMBlocking(tt.args.ctx, tt.args.userID, tt.args.targetUserID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("client.UndoDMBlocking() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("client.UndoDMBlocking() mismatch (-want +got):\n%s", diff)
+				return
+			}
+		})
+	}
+}

--- a/endpoint.go
+++ b/endpoint.go
@@ -133,6 +133,12 @@ const (
 )
 
 const (
+	// DM Blocks
+	postDMBlockingURL = "https://api.twitter.com/2/users/%v/dm/block"
+	undoDMBlockingURL = "https://api.twitter.com/2/users/%v/dm/unblock"
+)
+
+const (
 	// Community Notes
 	searchPostsEligibleForNotesURL = "https://api.x.com/2/notes/search/posts_eligible_for_notes"
 	searchNotesWrittenURL          = "https://api.x.com/2/notes/search/notes_written"


### PR DESCRIPTION
- Added postDMBlockingURL and undoDMBlockingURL endpoint constants
- Added DM Blocks methods to DirectMessages interface
- Extended direct_message.go with DM blocking data structures
- Created dm_blocks.go with implementation functions
- Added client methods for DM blocking operations
- Added comprehensive tests covering success and error scenarios

Implements DM Blocks management endpoints:
- POST /2/users/{id}/dm/block - Block DMs from a user
- DELETE /2/users/{id}/dm/unblock - Unblock DMs from a user

Features:
- DM-specific blocking (separate from regular user blocking)
- Granular control over direct message communications
- Proper error handling for various scenarios
- JSON request/response handling

close #207